### PR TITLE
CursorColor in .hyper.js is ignored

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ exports.decorateConfig = (config) => {
     foregroundColor: '#eceff1',
     backgroundColor: `rgba(38, 50, 56, ${ config.backgroundOpacity || '1' })`,
     borderColor: '#37474F',
-    cursorColor: '#FFCC00',
+    cursorColor: `${ config.cursorColor || '#FFCC00'}`,
     theme: `${ config.theme || '' }`,
     colors,
     termCSS: `


### PR DESCRIPTION
This may have been by design, however I wanted my cursor set to a specific color, and the theme was ignoring my setting and using a hard-coded color that could not be changed. I've added the fallback to the default of `#FFCC00` when `cursorColor` is not present in the config.

It may be wise to add this to the other options that are user configurable, to allow customization as the user sees fit.

Thanks!

Before (Default Cursor):
![screen shot 2017-03-07 at 23 54 35](https://cloud.githubusercontent.com/assets/137686/23693386/74aba328-0391-11e7-9eb2-213bf452d932.png)


After (with Custom `cursorColor`):
![screen shot 2017-03-07 at 23 55 55](https://cloud.githubusercontent.com/assets/137686/23693480/e47a9be6-0391-11e7-8be0-bf427f700306.png)
