### PR TITLE
Fixed Readme for adding custom conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ plugins: ['hyper-material-theme'],
 
 
 ## Configuration
-This theme provides 4 additional settings that you can add in your `~/.hyper.js` file **directly after** the colors object.
+This theme provides 4 additional settings that you can add in your `~/.hyper.js` file **directly after** the `colors` array, within the `config` object.
 
 ```js
-   colors: {...
-    },
-
+   colors: [
+    ...
+   ],
+   
     // Set the theme variant,
     // OPTIONS: 'Darker', 'Palenight', ''
     theme: '',


### PR DESCRIPTION
The custom configuration should be within the `config` object. Also the `colors` object is an array instead.

Ex: 

```js
module.exports = {
  config: {
    
    // Other options 
    ...


    colors: [
       ...
    ],

    theme: 'Palenight', 
    accentColor: '#64FFDA',
  }

...
```